### PR TITLE
Multiple username types and documentation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ uaac token client get <admin client name> -s <admin client secret>
 
 ##Create the client with the following uaac commands:
 ```
-uaac client add cf_users_client \
+uaac client add cf_portal_client \
  --authorities scim.write,scim.read,cloud_controller.read,cloud_controller.write,password.write,uaa.admin,uaa.resource,clo
 ud_controller.admin \
  --authorized_grant_types authorization_code,client_credentials,password \
@@ -20,8 +20,8 @@ ud_controller.admin \
  --scope openid,scim.write,scim.read,cloud_controller.read,cloud_controller.write,password.write,console.admin,console.sup
 port,cloud_controller.admin \
  -s <cf_users client secret>
-uaac client update cf_users_client --autoapprove true
-uaac client update cf_users_client --autoapprove true --authorized_grant_types authorization_code,client_credentials,pass
+uaac client update cf_portal_client --autoapprove true
+uaac client update cf_portal_client --autoapprove true --authorized_grant_types authorization_code,client_credentials,pass
 word,implicit
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ cf cups  cloud_foundry_api -p '{  "alias": "cloud_foundry_api",
                                   "portal-admin-pw" : "<administror user password  Base64 encoded>" ,
                                   "default-email-domain" : "<email domain of active directory users for example who@cloudfoundry.com would have an email domain of cloudfoundry.com>",
                                   "saml-provider" : "<saml provider name, this field is optional>" }'
+                                  "user-name-type" : "<type of username for login.  email or samaccountname}'
                                                              
 ```
 The guids can be retrieved utilizing the uaac users command.

--- a/README.md
+++ b/README.md
@@ -39,16 +39,16 @@ cf target -o <organization name> -s <space name>
 ## Create the user provided service for cloud_foundry_api
 ```
 cf cups  cloud_foundry_api -p '{  "alias": "cloud_foundry_api",
-                                  "domain": "<domain name for cloud foundry api rest services>",
-                                  "uaa-domain":"<domain name for uaa rest services>",
-                                  "login-domain" : "<domain name for login url for authentication>m",
+                                  "domain": "<domain name for cloud foundry api rest services for example domain.com>",
+                                  "uaa-domain":"<domain name for uaa rest services for example uaa.domain.com>",
+                                  "login-domain" : "<domain name for login url for authentication for example login.domain.com>",
                                   "uaa-client-id" : "<uaa client id Base64 encoded.>",
                                   "uaa-client-secret" : "<uaa client secret Base64 encoded>",
                                   "portal-admin-id" : "<administrator user id Base64 encoded>",
                                   "portal-admin-pw" : "<administror user password  Base64 encoded>" ,
                                   "default-email-domain" : "<email domain of active directory users for example who@cloudfoundry.com would have an email domain of cloudfoundry.com>",
                                   "saml-provider" : "<saml provider name, this field is optional>" }'
-                                  "user-name-type" : "<type of username for login.  email or samaccountname}'
+                                  "user-name-type" : "<type of username for users created through cf-users.  email or samaccountname>" }'
                                                              
 ```
 The guids can be retrieved utilizing the uaac users command.

--- a/routes/AdminOauth.coffee
+++ b/routes/AdminOauth.coffee
@@ -21,14 +21,6 @@ ao.initOauth2 = ()->
     saveToken = (error, result) ->
       if (error)
         console.log 'Access Token Error', JSON.stringify(error,0,2)
-        console.log('clientID is', credentials.clientID.toString())
-        console.log('clientSecret is',credentials.clientSecret.toString())
-        console.log('Site is', credentials.site.toString())
-        console.log('Authorization path is', credentials.site.toString() + credentials.authorizationPath.toString())
-        console.log('Token path is', credentials.site.toString() + credentials.tokenPath.toString())
-        console.log('Revocation path is', credentials.site.toString() + credentials.revocationPath.toString())
-        console.log("Admin ID is #{services["cloud_foundry_api-portal-admin-id"].b64}")
-        console.log("Admin password is #{services["cloud_foundry_api-portal-admin-pw"].b64}")
         reject("error fetching access token")
       else
         ao.token = oauth2.accessToken.create(result);

--- a/routes/AdminOauth.coffee
+++ b/routes/AdminOauth.coffee
@@ -21,6 +21,14 @@ ao.initOauth2 = ()->
     saveToken = (error, result) ->
       if (error)
         console.log 'Access Token Error', JSON.stringify(error,0,2)
+        console.log('clientID is', credentials.clientID.toString())
+        console.log('clientSecret is',credentials.clientSecret.toString())
+        console.log('Site is', credentials.site.toString())
+        console.log('Authorization path is', credentials.site.toString() + credentials.authorizationPath.toString())
+        console.log('Token path is', credentials.site.toString() + credentials.tokenPath.toString())
+        console.log('Revocation path is', credentials.site.toString() + credentials.revocationPath.toString())
+        console.log("Admin ID is #{services["cloud_foundry_api-portal-admin-id"].b64}")
+        console.log("Admin password is #{services["cloud_foundry_api-portal-admin-pw"].b64}")
         reject("error fetching access token")
       else
         ao.token = oauth2.accessToken.create(result);

--- a/routes/cfapi.coffee
+++ b/routes/cfapi.coffee
@@ -234,9 +234,10 @@ buildUaacRequest = (req)->
     when "samaccountname" then lowerId
     else ""
 
-  if (userNameType == "") then console.log("User Name Type was not valid.  Defaulting to Email address.")
+  if (userNameType == "") then console.log("User Name Type was not valid.  Defaulting to Email address.");userNameType = email
 
-  #console.log("User name type is",services["cloud_foundry_api-user-name-type"].value)
+  #console.log("User name type in manifest is",services["cloud_foundry_api-user-name-type"].value)
+  #console.log("user name type in program is",userNameType)
   #console.log("Email is",email)
   #console.log("SamAccountName is",lowerId)
 

--- a/routes/cfapi.coffee
+++ b/routes/cfapi.coffee
@@ -230,7 +230,7 @@ buildUaacRequest = (req)->
   familyName = if(identityProvider!="uaa") then services["cloud_foundry_api-default-email-domain"].value else lowerId
   uaacRequest =
     "schemas":["urn:scim:schemas:core:1.0"]
-    "userName":email
+    "userName":lowerId
     "name":
       "familyName": "#{familyName}"
       "givenName": "#{givenName}"

--- a/routes/cfapi.coffee
+++ b/routes/cfapi.coffee
@@ -236,11 +236,6 @@ buildUaacRequest = (req)->
 
   if (userNameType == "") then console.log("User Name Type was not valid.  Defaulting to Email address.");userNameType = email
 
-  #console.log("User name type in manifest is",services["cloud_foundry_api-user-name-type"].value)
-  #console.log("user name type in program is",userNameType)
-  #console.log("Email is",email)
-  #console.log("SamAccountName is",lowerId)
-
   uaacRequest =
     "schemas":["urn:scim:schemas:core:1.0"]
     "userName": userNameType

--- a/routes/cfapi.coffee
+++ b/routes/cfapi.coffee
@@ -228,9 +228,21 @@ buildUaacRequest = (req)->
   givenName = userIdComponents[0]
   email = if (identityProvider!="uaa") then "#{lowerId}@#{services["cloud_foundry_api-default-email-domain"].value}" else lowerId
   familyName = if(identityProvider!="uaa") then services["cloud_foundry_api-default-email-domain"].value else lowerId
+
+  userNameType = switch(services["cloud_foundry_api-user-name-type"].value)
+    when "email" then email
+    when "samaccountname" then lowerId
+    else ""
+
+  if (userNameType == "") then console.log("User Name Type was not valid.  Defaulting to Email address.")
+
+  #console.log("User name type is",services["cloud_foundry_api-user-name-type"].value)
+  #console.log("Email is",email)
+  #console.log("SamAccountName is",lowerId)
+
   uaacRequest =
     "schemas":["urn:scim:schemas:core:1.0"]
-    "userName":lowerId
+    "userName": userNameType
     "name":
       "familyName": "#{familyName}"
       "givenName": "#{givenName}"


### PR DESCRIPTION
Implements the ability to control the username type through the User Provided Service (we use samaccountname for consistency with other system logins).  Two types are available:

"user-name-type" : "email"}'
"user-name-type" : "samaccountname"}'

Also, cleaned up documentation pull requests I submitted earlier.
